### PR TITLE
Added Custom explicit `Content-Type` header

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -141,7 +141,9 @@ function setBody(options) {
 
 function setRequestHeaders(options) {
     let headers = options.headers || {};
-    headers = mergeJSON(headers, {"Content-Type": "application/json"});
+    if (! headers['Content-Type']) {
+        headers = mergeJSON(headers, {"Content-Type": "application/json"});
+    }
     options.headers = headers;
     return options;
 }


### PR DESCRIPTION
Hey guys, I need to get a pdf file using the `download_raw_document` method and it is downloading a json since the Content-Type header is always using `application/json`.

Reference: https://eversign.com/api/documentation/methods#download-original-pdf