### PR TITLE
Avoid override `params` with Authorization

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -150,12 +150,12 @@ function setRequestHeaders(options) {
 
 function setAuthorization(options) {
     sys.logs.info('[eversign] setting authorization');
-    options.params = {
-        access_key: config.get("apiKey"),
-    };
+    let params = options.params || {};
+    params = mergeJSON(params, { access_key: config.get("apiKey") })
     if (config.get("businessId")) {
-        options.params.business_id = config.get("businessId");
+        params = mergeJSON(params, { business_id: config.get("businessId") })
     }
+    options.params = params;
     return options;
 }
 


### PR DESCRIPTION
setAuthorization method is removing the params. I adapted it so it use the mergeJSON method to add the attributes to the params object